### PR TITLE
Replace hard-coded base64'd client ID with generated base64 client ID from variable

### DIFF
--- a/md4rd.el
+++ b/md4rd.el
@@ -108,8 +108,8 @@ Should be one of visit, upvote, downvote, open.")
   "Callback to run when the oauth code fetch is complete."
   (let-alist (plist-get data :data)
     (unless (and .access_token .refresh_token .expires_in)
-      (message "Failed to fetch OAuth access_token and refresh_token values!")
-      (error "Failed to fetch OAuth access_token and refresh_token values!"))
+      (message "md4rd: Failed to fetch OAuth access_token and refresh_token values!")
+      (error "md4rd: Failed to fetch OAuth access_token and refresh_token values!"))
     (setq md4rd--oauth-access-token .access_token)
     (setq md4rd--oauth-refresh-token .refresh_token)
     ;; @todo Handle expires_in value (should be ~1 hour, so refresh before then)
@@ -131,18 +131,17 @@ Should be one of visit, upvote, downvote, open.")
                        ("Authorization" . ,(format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id))))))))
 
 (cl-defun md4rd--oauth-fetch-callback-refresh-token (&rest data &allow-other-keys)
-  "Callback to run when the oauth code fetch is complete."
+  "Callback to run when the oauth refresh fetch is complete."
   (let-alist (plist-get data :data)
     (unless (and .access_token .expires_in)
-      (message "Failed to fetch OAuth access_token and refresh_token values!")
-      (error "Failed to fetch OAuth access_token and refresh_token values!"))
+      (message "md4rd: Failed to refresh the OAuth access token!")
+      (error "md4rd: Failed to refresh the OAuth access token!"))
     (setq md4rd--oauth-access-token .access_token)
-    (setq md4rd--oauth-refresh-token .refresh_token)
     ;; @todo Handle expires_in value (should be ~1 hour, so refresh before then)
-    (message "Tokens set - consider adding md4rd--oauth-access-token and md4rd--oauth-refresh-token values to your init file to avoid signing in again in the future sessions.")))
+    (message "md4rd tokens refreshed.")))
 
 (defun md4rd--oauth-fetch-refresh-token ()
-  "Make the initial code request for OAuth."
+  "Make a request for a new OAuth access token using the permanent refresh token."
   (request-response-data
    (request md4rd--oauth-access-token-uri
             :complete #'md4rd--oauth-fetch-callback-refresh-token
@@ -161,6 +160,11 @@ Should be one of visit, upvote, downvote, open.")
   (md4rd--oauth-browser-fetch)
   (call-interactively #'md4rd-oauth-set-code)
   (md4rd--oauth-fetch-authorization-token))
+
+(defun md4rd-refresh-login ()
+  "Refresh the OAuth authentication token (lifetime 3600 seconds)."
+  (interactive)
+  (md4rd--oauth-fetch-refresh-token))
 
 ;; For comment votes, the usable id is just the 'name' property.
 (defun md4rd--post-vote (id dir)

--- a/md4rd.el
+++ b/md4rd.el
@@ -128,7 +128,7 @@ Should be one of visit, upvote, downvote, open.")
             :parser #'json-read
             :headers `(("User-Agent" . "md4rd")
                        ;; This is just the 'client_id:' base64'ed
-                       ("Authorization" . (format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id) t)))))))
+                       ("Authorization" . ,(format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id))))))))
 
 (cl-defun md4rd--oauth-fetch-callback-refresh-token (&rest data &allow-other-keys)
   "Callback to run when the oauth code fetch is complete."
@@ -153,7 +153,7 @@ Should be one of visit, upvote, downvote, open.")
             :parser #'json-read
             :headers `(("User-Agent" . "md4rd")
                        ;; This is just the 'client_id:' base64'ed
-                       ("Authorization" . (format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id) t)))))))
+                       ("Authorization" . ,(format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id))))))))
 
 (defun md4rd-login ()
   "Sign into the reddit system via OAuth, to allow use of authenticated endpoints."

--- a/md4rd.el
+++ b/md4rd.el
@@ -128,7 +128,7 @@ Should be one of visit, upvote, downvote, open.")
             :parser #'json-read
             :headers `(("User-Agent" . "md4rd")
                        ;; This is just the 'client_id:' base64'ed
-                       ("Authorization" . "Basic RmFFVWloQjM5MXFUd0E6")))))
+                       ("Authorization" . (format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id) t)))))))
 
 (cl-defun md4rd--oauth-fetch-callback-refresh-token (&rest data &allow-other-keys)
   "Callback to run when the oauth code fetch is complete."
@@ -153,7 +153,7 @@ Should be one of visit, upvote, downvote, open.")
             :parser #'json-read
             :headers `(("User-Agent" . "md4rd")
                        ;; This is just the 'client_id:' base64'ed
-                       ("Authorization" . "Basic RmFFVWloQjM5MXFUd0E6")))))
+                       ("Authorization" . (format "Basic %s" (base64-encode-string (format "%s:" md4rd--oauth-client-id) t)))))))
 
 (defun md4rd-login ()
   "Sign into the reddit system via OAuth, to allow use of authenticated endpoints."

--- a/md4rd.el
+++ b/md4rd.el
@@ -138,7 +138,7 @@ Should be one of visit, upvote, downvote, open.")
       (error "md4rd: Failed to refresh the OAuth access token!"))
     (setq md4rd--oauth-access-token .access_token)
     ;; @todo Handle expires_in value (should be ~1 hour, so refresh before then)
-    (message "md4rd tokens refreshed.")))
+    (message "md4rd: Access token refreshed.")))
 
 (defun md4rd--oauth-fetch-refresh-token ()
   "Make a request for a new OAuth access token using the permanent refresh token."


### PR DESCRIPTION
In the interests of allowing users to setup their own Reddit API endpoint and obtain tokens using their own redirect URI, I've modified the two lines where hard-coded base64 client IDs were present (131 and 156) that prevented this. Those hard-coded values have been replaced with a base64 value generated from the `md4rd--oauth-client-id` variable (concatenated with ":"). This change will allow users to modify the client ID and redirect-uri variables in their config and obtain access and refresh tokens without needing to use a third-party website or rely on the continuance of a single API app.

For example:

    (use-package md4rd
    :ensure t
    :config (setq md4rd--oauth-client-id "fHHR39DrftwyWEPr0"
                  md4rd--oauth-redirect-uri "https://somepage.com/register"
                  md4rd--oauth-refresh-token "9998273466_HJ39yuW34pLjnkw"
                  md4rd-subs-active '(linux emacs orgmode)))

I've tested this pretty thoroughly (I think), and haven't found any issues with the change. Please let me know if there are any questions regarding the patch. Thanks!
