### PR TITLE
Fix double slash in fetch comments url

### DIFF
--- a/md4rd.el
+++ b/md4rd.el
@@ -585,7 +585,7 @@ return value of ACTIONFN is ignored."
              ((equal 'visit md4rd--action-button-ctx)
               (message "Fetching: %s" .permalink)
               (md4rd--fetch-comments
-               (format "http://reddit.com/%s.json" .permalink)))
+               (format "http://reddit.com%s.json" .permalink)))
 
              (t (error "Unknown link action!"))))))))))
   ;; (md4rd-widget-collapse-all 2)
@@ -652,7 +652,7 @@ return value of ACTIONFN is ignored."
                ((equal 'visit md4rd--action-button-ctx)
                 (message "Fetching: %s" .permalink)
                 (md4rd--fetch-comments
-                 (format "http://reddit.com/%s.json" .permalink)))
+                 (format "http://reddit.com%s.json" .permalink)))
 
                (t (error "Unknown link action!"))))))))
       buffer))


### PR DESCRIPTION
This PR fixes the fetching of comments by removing the double slash in the fetch comments url, which resulted in a request error (f.ex. `REQUEST [error] Error (error) while connecting to http://reddit.com//r/emacs/comments/g4z37e/oldschool_cool_ibm_vga8_font/.json.`).